### PR TITLE
Add support for category bounds

### DIFF
--- a/financial_planning_lib/src/asset.rs
+++ b/financial_planning_lib/src/asset.rs
@@ -472,7 +472,7 @@ mod test {
 
     #[test]
     fn test_category_basics() -> Result<()> {
-        let c = Category::from_assets(CategoryName("test1".to_string()), vec![]);
+        let c = Category::from_assets(CategoryName("test1".to_string()), vec![], None);
 
         assert_eq!(c.name, CategoryName("test1".to_string()));
         assert!(c.assets.is_empty());
@@ -496,7 +496,7 @@ mod test {
             },
         ];
 
-        let c = Category::from_assets(CategoryName("test2".to_string()), assets.clone());
+        let c = Category::from_assets(CategoryName("test2".to_string()), assets.clone(), None);
         assert_eq!(c.name, CategoryName("test2".to_string()));
         assert_eq!(c.assets, assets);
 
@@ -524,7 +524,7 @@ mod test {
             },
         ];
 
-        let c = Category::from_assets(CategoryName("test2".to_string()), assets.clone());
+        let c = Category::from_assets(CategoryName("test2".to_string()), assets.clone(), None);
         assert_eq!(c.name, CategoryName("test2".to_string()));
         assert_eq!(c.assets, assets);
 

--- a/financial_planning_lib/src/asset.rs
+++ b/financial_planning_lib/src/asset.rs
@@ -212,14 +212,29 @@ pub struct Tx {
 pub struct CategoryName(pub String);
 
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
+pub enum CategoryBound {
+    MustNotGoBelowZero,
+    MustNotGoAboveZero,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Category {
     pub name: CategoryName,
     pub assets: Vec<Asset>,
+    pub bound: Option<CategoryBound>,
 }
 
 impl Category {
-    pub fn from_assets(name: CategoryName, assets: Vec<Asset>) -> Self {
-        Category { name, assets }
+    pub fn from_assets(
+        name: CategoryName,
+        assets: Vec<Asset>,
+        bound: Option<CategoryBound>,
+    ) -> Self {
+        Category {
+            name,
+            assets,
+            bound,
+        }
     }
 
     pub fn value<'a>(&'a self) -> CategoryValue<'a> {

--- a/financial_planning_lib/src/flow.rs
+++ b/financial_planning_lib/src/flow.rs
@@ -186,7 +186,8 @@ mod test {
                         vec![Asset {
                             name: AssetName("unit test asset".to_string()),
                             value: asset_value,
-                        }]
+                        }],
+                        None
                     )
                     .value(),
                 )
@@ -249,7 +250,7 @@ mod test {
 
         let out = f
             .calculate_transaction(
-                &Category::from_assets(CategoryName("unittest".to_string()), vec![]).value(),
+                &Category::from_assets(CategoryName("unittest".to_string()), vec![], None).value(),
                 &f.start,
             )
             .unwrap();

--- a/financial_planning_lib/src/model.rs
+++ b/financial_planning_lib/src/model.rs
@@ -192,6 +192,7 @@ impl<'a, 'b: 'a> CategoryModel<'a, 'b> {
             for tx in months_txns.values() {
                 self.category_value.apply_tx(tx);
             }
+            self.category_value.check_bound()?;
             all_transactions.insert(
                 time.month.clone(),
                 MonthlyReport {

--- a/financial_planning_lib/src/tax.rs
+++ b/financial_planning_lib/src/tax.rs
@@ -237,7 +237,8 @@ mod test {
                 .value_at(
                     &flow.start,
                     &flow,
-                    &Category::from_assets(CategoryName("unittest".to_string()), vec![]).value(),
+                    &Category::from_assets(CategoryName("unittest".to_string()), vec![], None)
+                        .value(),
                 )
                 .unwrap(),
             delta,

--- a/inputs/example/plan.toml
+++ b/inputs/example/plan.toml
@@ -26,7 +26,12 @@ standard_deduction = 25100
 # of money there is growing at X%. To transfer between things you will
 # need to make a once off flow to subtract from one and add to another
 # tax exempt.
-categories = ["cash", "401k", "uninvested"]
+categories = [
+  { name = "cash", bound = "must_not_go_below_zero" },
+  { name = "401k", bound = "must_not_go_below_zero" },
+  { name = "uninvested" },
+]
+
 # Which category should tax debt/refund flows to into/out of
 tax_category = "cash"
 


### PR DESCRIPTION
I want this feature so I can assert without looking visually that I'm not erroneously dipping negative into an asset / making mortgage go positive, that kind of thing.

One thing I'd like to add before merging this is a flag like `--only-warn-on-bounds-violations`. Otherwise I imagine bounds could become annoying since you can't ignore them and would have to comment it out in `plans.yaml`.